### PR TITLE
Camera

### DIFF
--- a/Scenes/Levels/testLevel.tscn
+++ b/Scenes/Levels/testLevel.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=7 format=2]
+
+[sub_resource type="BoxShape" id=1]
+
+[sub_resource type="CubeMesh" id=2]
+
+[sub_resource type="OpenSimplexNoise" id=5]
+seed = 11
+period = 58.7
+persistence = 0.719
+lacunarity = 3.1
+
+[sub_resource type="NoiseTexture" id=6]
+seamless = true
+noise = SubResource( 5 )
+
+[sub_resource type="SpatialMaterial" id=4]
+albedo_color = Color( 0.129412, 0.352941, 0.0431373, 1 )
+albedo_texture = SubResource( 6 )
+
+[sub_resource type="BoxShape" id=3]
+
+[node name="level" type="Spatial"]
+
+[node name="cameraBounds" type="Spatial" parent="."]
+
+[node name="StaticBody" type="StaticBody" parent="cameraBounds"]
+transform = Transform( 1, 0, 0, 0, 50, 0, 0, 0, 200, -50, 50, 0 )
+collision_layer = 32768
+collision_mask = 32768
+
+[node name="CollisionShape" type="CollisionShape" parent="cameraBounds/StaticBody"]
+shape = SubResource( 1 )
+
+[node name="StaticBody2" type="StaticBody" parent="cameraBounds"]
+transform = Transform( 1, 0, 0, 0, 50, 0, 0, 0, 200, 50, 50, 0 )
+collision_layer = 32768
+collision_mask = 32768
+
+[node name="CollisionShape" type="CollisionShape" parent="cameraBounds/StaticBody2"]
+shape = SubResource( 1 )
+
+[node name="StaticBody3" type="StaticBody" parent="cameraBounds"]
+transform = Transform( -4.37114e-08, 0, 200, 0, 50, 0, -1, 0, -8.74228e-06, 0, 50, 50 )
+collision_layer = 32768
+collision_mask = 32768
+
+[node name="CollisionShape" type="CollisionShape" parent="cameraBounds/StaticBody3"]
+shape = SubResource( 1 )
+
+[node name="StaticBody4" type="StaticBody" parent="cameraBounds"]
+transform = Transform( -4.37114e-08, 0, 200, 0, 50, 0, -1, 0, -8.74228e-06, 0, 50, -50 )
+collision_layer = 32768
+collision_mask = 32768
+
+[node name="CollisionShape" type="CollisionShape" parent="cameraBounds/StaticBody4"]
+shape = SubResource( 1 )
+
+[node name="ground" type="Spatial" parent="."]
+
+[node name="MeshInstance" type="MeshInstance" parent="ground"]
+transform = Transform( 70, 0, 0, 0, 1, 0, 0, 0, 70, 0, 0, 0 )
+mesh = SubResource( 2 )
+skeleton = NodePath("StaticBody")
+material/0 = SubResource( 4 )
+
+[node name="StaticBody" type="StaticBody" parent="ground/MeshInstance"]
+
+[node name="CollisionShape" type="CollisionShape" parent="ground/MeshInstance/StaticBody"]
+shape = SubResource( 3 )

--- a/Scenes/game.tscn
+++ b/Scenes/game.tscn
@@ -1,0 +1,27 @@
+[gd_scene format=2]
+
+[node name="game" type="Node"]
+
+[node name="control" type="Control" parent="."]
+margin_right = 40.0
+margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ui" type="Control" parent="control"]
+margin_right = 40.0
+margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="menus" type="Control" parent="control"]
+margin_right = 40.0
+margin_bottom = 40.0
+
+[node name="level" type="Spatial" parent="."]
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.559193, 0.829038, 0, -0.829038, 0.559193, 0, 0, 0 )
+visible = false

--- a/Scenes/game.tscn
+++ b/Scenes/game.tscn
@@ -1,10 +1,18 @@
-[gd_scene format=2]
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://Scenes/Levels/testLevel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Scripts/camera.gd" type="Script" id=2]
+
+[sub_resource type="SphereShape" id=1]
+
+[sub_resource type="SphereMesh" id=2]
 
 [node name="game" type="Node"]
 
 [node name="control" type="Control" parent="."]
-margin_right = 40.0
-margin_bottom = 40.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -19,9 +27,169 @@ __meta__ = {
 [node name="menus" type="Control" parent="control"]
 margin_right = 40.0
 margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="level" type="Spatial" parent="."]
+[node name="mainMenu" type="Control" parent="control/menus"]
+margin_right = 40.0
+margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 0.559193, 0.829038, 0, -0.829038, 0.559193, 0, 0, 0 )
+[node name="scrollBoundaries" type="Control" parent="control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="topMargin" type="MarginContainer" parent="control/scrollBoundaries"]
+anchor_right = 1.0
+margin_left = 30.0
+margin_right = -30.0
+margin_bottom = 30.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="top" type="Control" parent="control/scrollBoundaries/topMargin"]
+margin_right = 964.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 0, 30 )
+mouse_filter = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="leftMargin" type="MarginContainer" parent="control/scrollBoundaries"]
+anchor_bottom = 1.0
+margin_top = 30.0
+margin_right = 30.0
+margin_bottom = -30.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="left" type="Control" parent="control/scrollBoundaries/leftMargin"]
+margin_right = 30.0
+margin_bottom = 540.0
+rect_min_size = Vector2( 30, 0 )
+mouse_filter = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="bottomMargin" type="MarginContainer" parent="control/scrollBoundaries"]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 30.0
+margin_top = -30.0
+margin_right = -30.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="bottom" type="Control" parent="control/scrollBoundaries/bottomMargin"]
+margin_right = 964.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 0, 30 )
+mouse_filter = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="rightMargin" type="MarginContainer" parent="control/scrollBoundaries"]
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -30.0
+margin_top = 30.0
+margin_bottom = -30.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="right" type="Control" parent="control/scrollBoundaries/rightMargin"]
+margin_right = 30.0
+margin_bottom = 540.0
+rect_min_size = Vector2( 30, 0 )
+mouse_filter = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="topLeft" type="Control" parent="control/scrollBoundaries"]
+margin_right = 30.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 30, 30 )
+
+[node name="topRight" type="Control" parent="control/scrollBoundaries"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -30.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 30, 30 )
+
+[node name="bottomLeft" type="Control" parent="control/scrollBoundaries"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -30.0
+margin_top = -30.0
+rect_min_size = Vector2( 30, 30 )
+
+[node name="bottomRight" type="Control" parent="control/scrollBoundaries"]
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_top = -30.0
+margin_right = 30.0
+rect_min_size = Vector2( 30, 30 )
+
+[node name="level" parent="." instance=ExtResource( 1 )]
+
+[node name="cameraBall" type="KinematicBody" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 14, 0 )
 visible = false
+collision_mask = 32769
+script = ExtResource( 2 )
+scrollSpeed = 50
+panSpeed = 10
+heightAboveTerrain = 20.0
+
+[node name="CollisionShape" type="CollisionShape" parent="cameraBall"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0 )
+shape = SubResource( 1 )
+
+[node name="MeshInstance" type="MeshInstance" parent="cameraBall/CollisionShape"]
+mesh = SubResource( 2 )
+skeleton = NodePath("../..")
+material/0 = null
+
+[node name="Camera" type="Camera" parent="cameraBall"]
+transform = Transform( 1, 0, 0, 0, 0.559193, 0.829038, 0, -0.829038, 0.559193, 0, 0, 0 )
+
+[node name="RayCast" type="RayCast" parent="cameraBall"]
+enabled = true
+cast_to = Vector3( 0, -1000, 0 )
+
+[connection signal="mouse_entered" from="control/scrollBoundaries/topMargin/top" to="cameraBall" method="_on_top_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/topMargin/top" to="cameraBall" method="_on_top_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/leftMargin/left" to="cameraBall" method="_on_left_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/leftMargin/left" to="cameraBall" method="_on_left_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/bottomMargin/bottom" to="cameraBall" method="_on_bottom_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/bottomMargin/bottom" to="cameraBall" method="_on_bottom_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/rightMargin/right" to="cameraBall" method="_on_right_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/rightMargin/right" to="cameraBall" method="_on_right_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/topLeft" to="cameraBall" method="_on_topLeft_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/topLeft" to="cameraBall" method="_on_topLeft_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/topRight" to="cameraBall" method="_on_topRight_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/topRight" to="cameraBall" method="_on_topRight_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/bottomLeft" to="cameraBall" method="_on_bottomLeft_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/bottomLeft" to="cameraBall" method="_on_bottomLeft_mouse_exited"]
+[connection signal="mouse_entered" from="control/scrollBoundaries/bottomRight" to="cameraBall" method="_on_bottomRight_mouse_entered"]
+[connection signal="mouse_exited" from="control/scrollBoundaries/bottomRight" to="cameraBall" method="_on_bottomRight_mouse_exited"]

--- a/Scripts/camera.gd
+++ b/Scripts/camera.gd
@@ -10,6 +10,10 @@ var originalCameraPosition : Vector3 = Vector3()
 var mouseCameraMove : bool = false
 
 export(float, 0, 500) var heightAboveTerrain : float = 50.0
+export(float, 0, 10) var zoomSpeed : float = 1.0
+var heightMax : float = 100.0
+var heightMin : float = 10.0
+
 
 
 func _physics_process(delta: float) -> void:
@@ -25,14 +29,32 @@ func _physics_process(delta: float) -> void:
 		var ref = get_viewport().get_mouse_position()
 		originalMousePosition = ref
 		originalCameraPosition = transform.origin
+		mouseCameraMove = true
+	elif Input.is_action_just_released("scrollMouseMiddleButton"):
+		mouseCameraMove = false
 	# This happens while 'move_map' is pressed
 	if Input.is_action_pressed("scrollMouseMiddleButton"):
 		_do_mouse_movement()
 	
+	if Input.is_action_just_released("mouseScrollDown"):
+		_set_zoom(false)
+	elif Input.is_action_just_released("mouseScrollUp"):
+		_set_zoom(true)
 	
 	var linear_velocity = Vector3(scrollDirection.x, 0, scrollDirection.y) * scrollSpeed
 	if !mouseCameraMove:
 		move_and_slide(linear_velocity, Vector3( 0, 1, 0 ), true, 1, 0.5, true)
+
+
+func _set_zoom(zoomDirection: bool) -> void:
+	if zoomDirection:
+		#zoomIn
+		var newHeight = heightAboveTerrain - zoomSpeed
+		heightAboveTerrain = clamp(newHeight, heightMin, heightMax)
+	else:
+		#zoomOut
+		var newHeight = heightAboveTerrain + zoomSpeed
+		heightAboveTerrain = clamp(newHeight, heightMin, heightMax)
 
 
 func _do_mouse_movement() -> void:
@@ -57,12 +79,6 @@ func _set_height() -> void:
 #	$RayCast.force_raycast_update()
 	var rayCollisionPoint = $RayCast.get_collision_point()
 	self.transform.origin.y = rayCollisionPoint.y + heightAboveTerrain
-
-
-func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("scrollMouseMiddleButton"):
-		originalMousePosition = event.position
-		mouseCameraMove = true
 
 
 # Should probably replace this with just a check through code, but this came

--- a/Scripts/camera.gd
+++ b/Scripts/camera.gd
@@ -1,0 +1,131 @@
+extends KinematicBody
+
+export(int, 0, 100) var scrollSpeed : int = 100 
+export(int, 0, 100) var panSpeed : int = 100
+
+var scrollDirection : Vector2 = Vector2()
+var mouseScroll : Vector2 = Vector2()
+var originalMousePosition : Vector2 = Vector2()
+var originalCameraPosition : Vector3 = Vector3()
+var mouseCameraMove : bool = false
+
+export(float, 0, 500) var heightAboveTerrain : float = 50.0
+
+
+func _physics_process(delta: float) -> void:
+	_get_scroll_direction()
+	# We don't want to move on the y-axis with scroll movement.
+	# Instead y-position will be handle by a raycast, so that the camera
+	# follows topology.
+	_set_height()
+	
+	# Do middle-mouse button movement first, for reasons?
+	# This happens once 'move_map' is pressed
+	if Input.is_action_just_pressed("scrollMouseMiddleButton"):
+		var ref = get_viewport().get_mouse_position()
+		originalMousePosition = ref
+		originalCameraPosition = transform.origin
+	# This happens while 'move_map' is pressed
+	if Input.is_action_pressed("scrollMouseMiddleButton"):
+		_do_mouse_movement()
+	
+	
+	var linear_velocity = Vector3(scrollDirection.x, 0, scrollDirection.y) * scrollSpeed
+	if !mouseCameraMove:
+		move_and_slide(linear_velocity, Vector3( 0, 1, 0 ), true, 1, 0.5, true)
+
+
+func _do_mouse_movement() -> void:
+	var ref = get_viewport().get_mouse_position()
+	transform.origin.x = originalCameraPosition.x + (originalMousePosition.x - ref.x)/80 * panSpeed
+	transform.origin.z = originalCameraPosition.z + (originalMousePosition.y - ref.y)/80 * panSpeed
+
+
+func _get_scroll_direction() -> void:
+	# From the arrow keys, or whatever other keys they're attached to
+	var LRStrength = Input.get_axis("scrollLeft", "scrollRight")
+	var UDStrength = Input.get_axis("scrollUp", "scrollDown")
+	scrollDirection = Vector2(LRStrength, UDStrength)
+	# Since I'm overwriting scrollDirection every frame, I need to take into
+	# account the mouse scrolling.
+	scrollDirection += mouseScroll
+	scrollDirection = scrollDirection.normalized()
+
+
+func _set_height() -> void:
+	# Probably don't need to force update, since we're checking before moving.
+#	$RayCast.force_raycast_update()
+	var rayCollisionPoint = $RayCast.get_collision_point()
+	self.transform.origin.y = rayCollisionPoint.y + heightAboveTerrain
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("scrollMouseMiddleButton"):
+		originalMousePosition = event.position
+		mouseCameraMove = true
+
+
+# Should probably replace this with just a check through code, but this came
+# to mind first.
+func _on_top_mouse_entered() -> void:
+	mouseScroll.y -= 1
+
+
+func _on_top_mouse_exited() -> void:
+	mouseScroll.y += 1
+
+
+func _on_left_mouse_entered() -> void:
+	mouseScroll.x -= 1
+
+
+func _on_left_mouse_exited() -> void:
+	mouseScroll.x += 1
+
+
+func _on_bottom_mouse_entered() -> void:
+	mouseScroll.y += 1
+
+
+func _on_bottom_mouse_exited() -> void:
+	mouseScroll.y -= 1
+
+
+func _on_right_mouse_entered() -> void:
+	mouseScroll.x += 1
+
+
+func _on_right_mouse_exited() -> void:
+	mouseScroll.x -= 1
+
+
+func _on_topLeft_mouse_entered() -> void:
+	mouseScroll += Vector2(-1, -1)
+
+
+func _on_topLeft_mouse_exited() -> void:
+	mouseScroll -= Vector2(-1, -1)
+
+
+func _on_topRight_mouse_entered() -> void:
+	mouseScroll += Vector2(1, -1)
+
+
+func _on_topRight_mouse_exited() -> void:
+	mouseScroll -= Vector2(1, -1)
+
+
+func _on_bottomLeft_mouse_entered() -> void:
+	mouseScroll += Vector2(1, 1)
+
+
+func _on_bottomLeft_mouse_exited() -> void:
+	mouseScroll -= Vector2(1, 1)
+
+
+func _on_bottomRight_mouse_entered() -> void:
+	mouseScroll += Vector2(-1, 1)
+
+
+func _on_bottomRight_mouse_exited() -> void:
+	mouseScroll -= Vector2(-1, 1)

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,34 @@ config/name="Simple Rts"
 run/main_scene="res://Scenes/game.tscn"
 config/icon="res://Assets/Textures/icon.png"
 
+[input]
+
+scrollLeft={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777231,"unicode":0,"echo":false,"script":null)
+ ]
+}
+scrollRight={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777233,"unicode":0,"echo":false,"script":null)
+ ]
+}
+scrollUp={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777232,"unicode":0,"echo":false,"script":null)
+ ]
+}
+scrollDown={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777234,"unicode":0,"echo":false,"script":null)
+ ]
+}
+scrollMouseMiddleButton={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":3,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+
 [physics]
 
 common/enable_pause_aware_picking=true

--- a/project.godot
+++ b/project.godot
@@ -41,6 +41,16 @@ scrollMouseMiddleButton={
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":3,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+mouseScrollDown={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":5,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+mouseScrollUp={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":4,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
 
 [physics]
 

--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=4
 [application]
 
 config/name="Simple Rts"
+run/main_scene="res://Scenes/game.tscn"
 config/icon="res://Assets/Textures/icon.png"
 
 [physics]


### PR DESCRIPTION
Added the basics of camera movement.
- Basic zoom in and out, with clamped min and max
- Edge scrolling with the mouse
- Scrolling with arrow keys
- Map movement using middle mouse button
- Camera should follow terrain topography due to raycast-set height

Camera is bounded by camera bounding bodies in the level - these _must_ be present to prevent camera flyoff.